### PR TITLE
Fixed check_term() return value

### DIFF
--- a/pydealer/pydealer.py
+++ b/pydealer/pydealer.py
@@ -107,6 +107,8 @@ class Deck(object):
         for check in check_list:
             if check == term:
                 return True
+        else:
+            return False
 
     def deal(self, num=1, rebuild=True):
         """


### PR DESCRIPTION
Changed `check_term()` to return False if the term matched none of the checks in check_list.
