### PR TITLE
Allow to shuffle the deck multiple times

### DIFF
--- a/pydealer/pydealer.py
+++ b/pydealer/pydealer.py
@@ -404,9 +404,14 @@ class Deck(object):
         else:
             return None
 
-    def shuffle(self):
-        """Shuffles the deck."""
-        random.shuffle(self.cards)
+    def shuffle(self, times=1):
+        """
+        Shuffles the deck.
+        :param times: The number of times to shuffle the deck.
+        :type times: int.
+        """
+        for _ in range(5):
+            random.shuffle(self.cards)
 
     @property
     def size(self):


### PR DESCRIPTION
There are some card games that it's common to shuffle the card stack more than one time before dealing the cards. I added a new parameter to the shuffle function in order two allow the user to select the number of time they wants to shuflle the stactk. 

A default parameter of 1 is provided if it's not specified. 
