### PR TITLE
Fix Stack.find operations that use sort=1 by adding a missing include

### DIFF
--- a/pydealer/card.py
+++ b/pydealer/card.py
@@ -186,7 +186,7 @@ class Card(object):
                     ranks["suits"][other.suit]
                 )
             else:
-                return ranks[self.value] == ranks[other.value]
+                return ranks["values"][self.value] == ranks["values"][other.value]
         else:
             return False
 
@@ -219,7 +219,7 @@ class Card(object):
                     )
                 )
             else:
-                return ranks[self.value] >= ranks[other.value]
+                return ranks["values"][self.value] >= ranks["values"][other.value]
         else:
             return False
 
@@ -251,7 +251,7 @@ class Card(object):
                     )
                 )
             else:
-                return ranks[self.value] > ranks[other.value]
+                return ranks["values"][self.value] > ranks["values"][other.value]
         else:
             return False
 
@@ -284,7 +284,7 @@ class Card(object):
                     )
                 )
             else:
-                return ranks[self.value] <= ranks[other.value]
+                return ranks["values"][self.value] <= ranks["values"][other.value]
         else:
             return False
 
@@ -316,7 +316,7 @@ class Card(object):
                     )
                 )
             else:
-                return ranks[self.value] < ranks[other.value]
+                return ranks["values"][self.value] < ranks["values"][other.value]
         else:
             return False
 
@@ -344,7 +344,7 @@ class Card(object):
                     ranks["suits"][other.suit]
                 )
             else:
-                return ranks[self.value] != ranks[other.value]
+                return ranks["values"][self.value] != ranks["values"][other.value]
         else:
             return False
 

--- a/pydealer/stack.py
+++ b/pydealer/stack.py
@@ -35,6 +35,7 @@ from pydealer.tools import (
     open_cards,
     random_card,
     save_cards,
+    sort_card_indices,
     sort_cards
 )
 

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -14,6 +14,7 @@
 import unittest
 
 import pydealer
+from pydealer.const import POKER_RANKS
 
 
 #===============================================================================
@@ -131,6 +132,14 @@ class TestCard(unittest.TestCase):
         two_diamonds = pydealer.Card("2", "Diamonds")
 
         result = self.card.lt(two_diamonds)
+
+        self.assertFalse(result)
+
+    def test_lt_with_custom_rank(self):
+        """"""
+        two_diamonds = pydealer.Card("2", "Diamonds")
+
+        result = self.card.lt(two_diamonds, ranks=POKER_RANKS)
 
         self.assertFalse(result)
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -147,6 +147,13 @@ class TestStack(unittest.TestCase):
 
         self.assertEqual(len(found), 1)
 
+    def test_find_sort(self):
+        """"""
+        found = self.full_stack.find("Spades", sort=True)
+
+        self.assertEqual(len(found), 13)
+        self.assertEqual(self.full_stack[found[0]].value, "2")
+
     def test_find_list_full(self):
         """"""
         full_list = ["Ace of Spades", "2 of Diamonds", "Queen of Hearts",


### PR DESCRIPTION
Stack.find(..., sort=True) fails, because sort_card_indices is undefined. This fixes that problem, and adds a test to ensure it is working.